### PR TITLE
Update setup.py to new scikit-learn name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import sys
 import platform
 
-install_requires = ["tqdm>=4.41.1", "numpy", "sklearn", "torch"]
+install_requires = ["tqdm>=4.41.1", "numpy", "scikit-learn", "torch"]
 
 setup(name='speculator',
       version='v0.2',


### PR DESCRIPTION
Scikit-learn dep must be updated for pip install to work. 

The kids project needs to install speculator from the torch branch and currently the project's environment.yaml conda env creation is breaking due to this dependency. 